### PR TITLE
Upgrade 'eslint-config-prettier' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint-config-airbnb": "^17.1.0",
-    "eslint-config-prettier": "^4.0.0",
+    "eslint-config-prettier": "^5.0.0",
     "eslint-plugin-flowtype": "^3.4.2",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,11 +90,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@kiwicom/eslint-config-nitro@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/eslint-config-nitro/-/eslint-config-nitro-1.0.0.tgz#3daab60afb167ae0e9bd3b388494cd52082d962f"
-  integrity sha512-dneZYAEKprFyG0iAKucBGZyXICJxKuAvd7fCurQ716b+GogEeCZA0Mq8d6libCHYAu/RegPMYy5xJwcfRg85YA==
-
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
@@ -395,10 +390,10 @@ eslint-config-airbnb@^17.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-prettier@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz#16cedeea0a56e74de60dcbbe3be0ab2c645405b9"
-  integrity sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==
+eslint-config-prettier@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-5.0.0.tgz#f7a94b2b8ae7cbf25842c36fa96c6d32cd0a697c"
+  integrity sha512-c17Aqiz5e8LEqoc/QPmYnaxQFAHTx2KlCZBPxXXjEMmNchOLnV/7j0HoPZuC+rL/tDC9bazUYOKJW9bOhftI/w==
   dependencies:
     get-stdin "^6.0.0"
 


### PR DESCRIPTION
Changelog: https://github.com/prettier/eslint-config-prettier/blob/master/CHANGELOG.md#version-500-2019-06-15

Not sure if you use this dependency. It's blocking us because it's conflicting with our major version in a different package. Could you please release a new version?